### PR TITLE
Added thread safe lock to client

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
 ignore:
   - gocd/gen_*.go
   - gen_*.go
+
+coverage:
+  precision: 2
+  round: down
+  range: "90...100"


### PR DESCRIPTION
To help with read and updates of resources with versions, added `gocd.Client.Lock()` and `gocd.Client.Unlock()` to avoid race conditions.