### PR TITLE
Exposed configuration loading

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,10 +7,11 @@ import (
 	"github.com/urfave/cli"
 )
 
+// NewCliClient
 func cliAgent(c *cli.Context) *gocd.Client {
-
-	cfg, err := loadConfig()
-	if err != nil {
+	var cfg *gocd.Configuration
+	var err error
+	if cfg, err = gocd.LoadConfig(); err != nil {
 		panic(err)
 	}
 

--- a/gocd/client.go
+++ b/gocd/client.go
@@ -1,0 +1,6 @@
+package gocd
+
+// ClientFromConfiguration loads configs from files if they exist, and returns a gocd client
+//func ClientFromConfiguration() *Client {
+//	return gcli.NewCliClient(nil)
+//}

--- a/gocd/config.go
+++ b/gocd/config.go
@@ -1,9 +1,58 @@
 package gocd
 
-//import "context"
-//
-//type Config struct {
-//
-//}
+import (
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"strings"
+)
 
-//func (pts *PipelineTemplatesService) Get(ctx context.Context) (*Config, *APIResponse, error) {
+// ConfigDirectoryPath is the location where the authentication information is stored
+const ConfigDirectoryPath = "~/.gocd.conf"
+
+// Environment variables for configuration.
+const (
+	EnvVarServer   = "GOCD_SERVER"
+	EnvVarUsername = "GOCD_USERNAME"
+	EnvVarPassword = "GOCD_PASSWORD"
+	EnvVarSkipSsl  = "GOCD_SKIP_SSL_CHECK"
+)
+
+// LoadConfig loads configurations from yaml at default file location
+func LoadConfig() (*Configuration, error) {
+	var b []byte
+	cfg := &Configuration{}
+
+	p := ConfigFilePath()
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		if b, err = ioutil.ReadFile(p); err != nil {
+			return nil, err
+		}
+
+		if err = yaml.Unmarshal(b, &cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	if server := os.Getenv(EnvVarServer); server != "" {
+		cfg.Server = server
+	}
+
+	if username := os.Getenv(EnvVarUsername); username != "" {
+		cfg.Username = username
+	}
+
+	if password := os.Getenv(EnvVarPassword); password != "" {
+		cfg.Password = password
+	}
+
+	return cfg, nil
+}
+
+// ConfigFilePath specifies the default path to a config file
+func ConfigFilePath() string {
+	// @TODO Make it work for windows. Maybe...
+	usr, _ := user.Current()
+	return strings.Replace(ConfigDirectoryPath, "~", usr.HomeDir, 1)
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	gocli "github.com/drewsonne/go-gocd/cli"
+	"github.com/drewsonne/go-gocd/gocd"
 	"github.com/urfave/cli"
 	"os"
 	"sort"
@@ -58,10 +59,10 @@ func main() {
 	}
 
 	app.Flags = []cli.Flag{
-		cli.StringFlag{Name: "server", EnvVar: gocli.EnvVarServer},
-		cli.StringFlag{Name: "username", EnvVar: gocli.EnvVarUsername},
-		cli.StringFlag{Name: "password", EnvVar: gocli.EnvVarPassword},
-		cli.BoolFlag{Name: "ssl_check", EnvVar: gocli.EnvVarSkipSsl},
+		cli.StringFlag{Name: "server", EnvVar: gocd.EnvVarServer},
+		cli.StringFlag{Name: "username", EnvVar: gocd.EnvVarUsername},
+		cli.StringFlag{Name: "password", EnvVar: gocd.EnvVarPassword},
+		cli.BoolFlag{Name: "ssl_check", EnvVar: gocd.EnvVarSkipSsl},
 	}
 
 	sort.Sort(cli.CommandsByName(app.Commands))


### PR DESCRIPTION
Made the path to the .gocd.cfg file part of the API, rather than just the CLI.