### PR TITLE
Switched err check back to original

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GoCD SDK 0.6.7
+# GoCD SDK 0.6.8
 
 [![GoDoc](https://godoc.org/github.com/drewsonne/go-gocd/gocd?status.svg)](https://godoc.org/github.com/drewsonne/go-gocd/gocd)
 [![Build Status](https://travis-ci.org/drewsonne/go-gocd.svg?branch=master)](https://travis-ci.org/drewsonne/go-gocd)

--- a/gocd/config.go
+++ b/gocd/config.go
@@ -68,7 +68,7 @@ func LoadConfigFromFile() (cfgs map[string]*Configuration, err error) {
 	if err != nil {
 		return
 	}
-	if _, err = os.Stat(p); os.IsExist(err) {
+	if _, err = os.Stat(p); !os.IsNotExist(err) {
 		if b, err = ioutil.ReadFile(p); err != nil {
 			return
 		}


### PR DESCRIPTION
Fixed a bug where when loading the config from disk, errors were being check for a file existing, _no_ checking wether a file does not exist.