### PR TITLE
Fix configure bug

### DIFF
--- a/cli/configure.go
+++ b/cli/configure.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/AlecAivazis/survey.v1"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	"os"
 )
 
 // List of command name and descriptions
@@ -36,8 +37,10 @@ func (car configActionRunner) run() (err error) {
 	}
 
 	cfgs, err := car.loadConfigs()
-	if err != nil {
-		return NewCliError("Configure:generate", nil, err)
+	if !os.IsNotExist(err) {
+		if err != nil {
+			return NewCliError("Configure:generate:load", nil, err)
+		}
 	}
 
 	if cfg, err = car.generateConfig(); err != nil {

--- a/gocd/config.go
+++ b/gocd/config.go
@@ -63,6 +63,7 @@ func LoadConfigByName(name string, cfg *Configuration) (err error) {
 // LoadConfigFromFile on disk and return it as a Configuration item
 func LoadConfigFromFile() (cfgs map[string]*Configuration, err error) {
 	var b []byte
+	cfgs = make(map[string]*Configuration)
 
 	p, err := ConfigFilePath()
 	if err != nil {
@@ -73,10 +74,11 @@ func LoadConfigFromFile() (cfgs map[string]*Configuration, err error) {
 			return
 		}
 
-		cfgs = make(map[string]*Configuration)
 		if err = yaml.Unmarshal(b, &cfgs); err != nil {
 			return
 		}
+	} else {
+		return
 	}
 
 	return


### PR DESCRIPTION
When first running `gocd configure`, if the conf file does not exist an error would be thrown instead of the file being created.

```
{
  "error": "stat /Users/me/.gocd.conf: no such file or directory",
  "request": "Configure:generate"
}
```